### PR TITLE
fix: missing mime type in login handler

### DIFF
--- a/src/authentication/login.handler.ts
+++ b/src/authentication/login.handler.ts
@@ -44,6 +44,7 @@ export const withLogin = (
         action: admin.options.loginPath,
         errorMessage: 'invalidCredentials',
       });
+      reply.type('text/html');
       reply.send(login);
     }
   });


### PR DESCRIPTION
- Issue description: in case of failed login a long plain text is displayed in the browser instead of a valid web page.
- Root cause: missing mime type definition before reply delivery  