### PR TITLE
fix: allow routes outside /admin when using authenticated router

### DIFF
--- a/src/authentication/protected-routes.handler.ts
+++ b/src/authentication/protected-routes.handler.ts
@@ -8,9 +8,10 @@ export const withProtectedRoutesHandler = (
   const { rootPath } = admin.options;
 
   fastifyApp.addHook('preHandler', async (request, reply) => {
-    if (AdminRouter.assets.find(asset => request.url.match(asset.path))) {
+    if (AdminRouter.assets.find((asset) => request.url.match(asset.path))) {
       return;
     } else if (
+      !request.url.startsWith(rootPath) ||
       request.session.adminUser ||
       // these routes doesn't need authentication
       request.url.startsWith(admin.options.loginPath) ||


### PR DESCRIPTION
- Issue: When authenticated router is enabled, cannot access regular APIs, outside /admin path, without being redirected to login page. Cannot use AdminJs side by side with other API endpoints
- Root cause: need an exclusion to be added in the protected-routes.handler.ts

PS: possible alternative solution, offer the possibility to configure the excluded routes via options