### PR TITLE
chore: update deprecated plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
     "typescript": "^4.0.5"
   },
   "dependencies": {
+    "@fastify/cookie": "^6.0.0",
+    "@fastify/formbody": "^7.0.0",
+    "@fastify/multipart": "^6.0.0",
     "fastify": "^3.18.0",
-    "fastify-cookie": "^5.3.1",
-    "fastify-formbody": "^5.0.0",
-    "fastify-multipart": "^4.0.6",
     "fastify-session": "^5.2.1",
     "lodash": "^4.17.21",
     "mime-types": "^2.1.34"

--- a/src/buildAuthenticatedRouter.ts
+++ b/src/buildAuthenticatedRouter.ts
@@ -5,9 +5,9 @@ import { AuthenticationOptions } from './types';
 import { withLogin } from './authentication/login.handler';
 import { withProtectedRoutesHandler } from './authentication/protected-routes.handler';
 import { FastifyInstance } from 'fastify';
-import fastifyCookie from 'fastify-cookie';
+import fastifyCookie from '@fastify/cookie';
 import fastifySession from 'fastify-session';
-import fastifyFormBody from 'fastify-formbody';
+import fastifyFormBody from '@fastify/formbody';
 import FastifySessionPlugin from 'fastify-session';
 import Options = FastifySessionPlugin.Options;
 /**

--- a/src/buildRouter.ts
+++ b/src/buildRouter.ts
@@ -8,7 +8,7 @@ import { fromPairs } from 'lodash';
 import * as fs from 'fs';
 import * as mime from 'mime-types';
 
-import fastifyMultipart from 'fastify-multipart';
+import fastifyMultipart from '@fastify/multipart';
 
 const INVALID_ADMIN_BRO_INSTANCE =
   'You have to pass an instance of AdminJS to the buildRouter() function';


### PR DESCRIPTION
Hello, when i run this project, it will show the warning message

```
[FST_MODULE_DEP_FASTIFY-COOKIE] FastifyWarning.fastify-cookie: fastify-cookie has been deprecated. Use @fastify/cookie@6.0.0 instead.
[FST_MODULE_DEP_FASTIFY-FORMBODY] FastifyWarning.fastify-formbody: fastify-formbody has been deprecated. Use @fastify/formbody@6.0.0 instead.
```

I had replaced them by @fastify/xxx module