### PR TITLE
Quick fix for adminjs-upload plugin

### DIFF
--- a/src/buildRouter.ts
+++ b/src/buildRouter.ts
@@ -44,10 +44,12 @@ const getFile = async (fileField) => {
     return null;
 };
 
+//@ts-ignore
 Array.prototype.asyncMap = async function (callback) {
     const result = [];
     for (let index = 0; index < this.length; index++) {
-        result.push(await callback(this[index], index, this));
+      //@ts-ignore
+      result.push(await callback(this[index], index, this));
     }
     return result;
 };
@@ -86,9 +88,10 @@ export const buildRouter = async (
         { value: string; file?: File }
       >;
       const fields = fromPairs(
-        await Object.keys((body ?? {}) as Record<string, unknown>).map(async key => [
+        //@ts-ignore
+        await Object.keys((body ?? {}) as Record<string, unknown>).asyncMap(async key => [
           key,
-          await getFile(body[key] as any) ?? body[key].value,
+          (await getFile(body[key] as any)) ?? body[key].value,
         ])
       );
       const html = await controller[route.action](


### PR DESCRIPTION
During file upload adminjs-upload relays on file.path https://github.com/SoftwareBrothers/adminjs-upload/blob/master/src/features/upload-file/providers/aws-provider.ts#L66 which is not provided by fastifyMultipart. TO quickly fix it in our project I created a temporary file (in tmp folder, but is not being deleted) and substituted instead of file object