### PR TITLE
fix: auth route handlers not ending correctly

### DIFF
--- a/src/authentication/login.handler.ts
+++ b/src/authentication/login.handler.ts
@@ -30,7 +30,7 @@ export const withLogin = (
       ...providerProps,
     });
     reply.type('text/html');
-    reply.send(login);
+    return reply.send(login);
   });
 
   fastifyInstance.post(loginPath, async (req, reply) => {
@@ -60,9 +60,9 @@ export const withLogin = (
       req.session.set('adminUser', adminUser);
 
       if (req.session.redirectTo) {
-        reply.redirect(302, req.session.redirectTo);
+        return reply.redirect(302, req.session.redirectTo);
       } else {
-        reply.redirect(302, rootPath);
+        return reply.redirect(302, rootPath);
       }
     } else {
       const login = await admin.renderLogin({
@@ -71,7 +71,7 @@ export const withLogin = (
         ...providerProps,
       });
       reply.type('text/html');
-      reply.send(login);
+      return reply.send(login);
     }
   });
 };

--- a/src/authentication/logout.handler.ts
+++ b/src/authentication/logout.handler.ts
@@ -20,13 +20,10 @@ export const withLogout = (
     if (provider) {
       await provider.handleLogout({ request, reply });
     }
-  
+
     if (request.session) {
-      request.session.destroy(() => {
-        reply.redirect(admin.options.loginPath);
-      })
-    } else {
-      reply.redirect(admin.options.loginPath);
+      await request.session.destroy();
     }
+    return reply.redirect(admin.options.loginPath);
   });
 };

--- a/src/authentication/protected-routes.handler.ts
+++ b/src/authentication/protected-routes.handler.ts
@@ -7,7 +7,7 @@ export const withProtectedRoutesHandler = (
 ): void => {
   const { rootPath } = admin.options;
 
-  fastifyApp.addHook('preHandler', async (request, reply) => {    
+  fastifyApp.addHook('preHandler', async (request, reply) => {
     const buildComponentRoute = AdminRouter.routes.find((r) => r.action === 'bundleComponents')?.path
     if (AdminRouter.assets.find((asset) => request.url.match(asset.path))) {
       return;
@@ -28,7 +28,7 @@ export const withProtectedRoutesHandler = (
         ? rootPath
         : redirectTo;
 
-      reply.redirect(admin.options.loginPath);
+      return reply.redirect(admin.options.loginPath);
     }
   });
 };

--- a/src/authentication/refresh.handler.ts
+++ b/src/authentication/refresh.handler.ts
@@ -54,8 +54,7 @@ export const withRefresh = (
     };
 
     request.session.set('adminUser', admin);
-    request.session.save(() => {
-      reply.send(admin);
-    });
+    await request.session.save();
+    return reply.send(admin);
   });
 };


### PR DESCRIPTION
The missing `return` in the protected routes handler caused the request to continue processing even after the redirect, leading to this error:

```
Error [ERR_HTTP_HEADERS_SENT]: Cannot write headers after they are sent to the client
    at ServerResponse.writeHead (node:_http_server:345:11)
    at safeWriteHead (/Users/user/code/project/node_modules/fastify/lib/reply.js:572:9)
    at onSendEnd (/Users/user/code/project/node_modules/fastify/lib/reply.js:621:5)
    at wrapOnSendEnd (/Users/user/code/project/node_modules/fastify/lib/reply.js:565:5)
    at next (/Users/user/code/project/node_modules/fastify/lib/hooks.js:289:7)
    at Object.fastifyCookieOnSendHandler (/Users/user/code/project/node_modules/@fastify/cookie/plugin.js:113:3)
    at next (/Users/user/code/project/node_modules/fastify/lib/hooks.js:295:30)
    at /Users/user/code/project/node_modules/@fastify/session/lib/fastifySession.js:201:9
    at Immediate._onImmediate (/Users/user/code/project/node_modules/@fastify/session/lib/session.js:180:11)
    at process.processImmediate (node:internal/timers:480:21) {
  code: 'ERR_HTTP_HEADERS_SENT'
}
```

Add returns to other async handlers too as is recommended.